### PR TITLE
Fix for issue with importing proto files from subpackages in another jar

### DIFF
--- a/src/main/java/com/google/protobuf/maven/AbstractProtocMojo.java
+++ b/src/main/java/com/google/protobuf/maven/AbstractProtocMojo.java
@@ -264,13 +264,14 @@ abstract class AbstractProtocMojo extends AbstractMojo {
                 for (JarEntry jarEntry : list(classpathJar.entries())) {
                     final String jarEntryName = jarEntry.getName();
                     if (jarEntry.getName().endsWith(PROTO_FILE_SUFFIX)) {
+                        File jarFileDirectory = new File(temporaryProtoFileDirectory,
+                                truncatePath(classpathJar.getName()));
                         final File uncompressedCopy =
-                                new File(new File(temporaryProtoFileDirectory,
-                                        truncatePath(classpathJar.getName())), jarEntryName);
+                                new File(jarFileDirectory, jarEntryName);
                         uncompressedCopy.getParentFile().mkdirs();
                         copyStreamToFile(new RawInputStreamFacade(classpathJar
                                 .getInputStream(jarEntry)), uncompressedCopy);
-                        protoDirectories.add(uncompressedCopy.getParentFile());
+                        protoDirectories.add(jarFileDirectory);
                     }
                 }
             } else if (classpathElementFile.isDirectory()) {


### PR DESCRIPTION
Fixes the issue where proto files in dependencies are incorrectly specified on the path if they reside in subpackages inside the jar

This is exactly the issue described by [sergei-ivanov](https://github.com/sergei-ivanov) in TEST-5 of his pull-request, https://github.com/sergei-ivanov/maven-protoc-plugin/blob/master/src/it/TEST-5/invoker.properties

I have also tested this fix against his pull-request by commenting out the `invoker.failureBehavior = fail-never` line in [invoker.properties](https://github.com/sergei-ivanov/maven-protoc-plugin/blob/master/src/it/TEST-5/invoker.properties)
