### PR TITLE
Add support for generating python sources files.

### DIFF
--- a/src/main/java/com/google/protobuf/maven/AbstractProtocMojo.java
+++ b/src/main/java/com/google/protobuf/maven/AbstractProtocMojo.java
@@ -160,6 +160,7 @@ abstract class AbstractProtocMojo extends AbstractMojo {
                             makeProtoPathFromJars(temporaryProtoFileDirectory, getDependencyArtifactFiles());
                     outputDirectory.mkdirs();
                     nativeOutputDirectory.mkdirs();
+
                     // Quick fix to fix issues with two mvn installs in a row (ie no clean)
                     cleanDirectory(outputDirectory);
 
@@ -167,7 +168,7 @@ abstract class AbstractProtocMojo extends AbstractMojo {
                             .addProtoPathElement(protoSourceRoot)
                             .addProtoPathElements(derivedProtoPathElements)
                             .addProtoPathElements(asList(additionalProtoPathElements))
-			    .addProtoFiles(protoFiles)
+                            .addProtoFiles(protoFiles)
                             .setNativeOutputDirectory(nativeOutputDirectory)
                             .setGeneratePythonSources(generatePythonSources)
                             .build();

--- a/src/main/java/com/google/protobuf/maven/AbstractProtocMojo.java
+++ b/src/main/java/com/google/protobuf/maven/AbstractProtocMojo.java
@@ -110,6 +110,14 @@ abstract class AbstractProtocMojo extends AbstractMojo {
     private boolean hashDependentPaths;
 
     /**
+     * Set this to {@code true} to generate python protocol buffer classes
+     * <p/>
+     * @parameter default-value="true"
+     * @required
+     */
+    private boolean generatePythonSources;
+
+    /**
      * @parameter
      */
     private Set<String> includes = ImmutableSet.of(DEFAULT_INCLUDES);
@@ -139,6 +147,7 @@ abstract class AbstractProtocMojo extends AbstractMojo {
             try {
                 ImmutableSet<File> protoFiles = findProtoFilesInDirectory(protoSourceRoot);
                 final File outputDirectory = getOutputDirectory();
+                final File nativeOutputDirectory = getNativeOutputDirectory();
                 ImmutableSet<File> outputFiles = findGeneratedFilesInDirectory(getOutputDirectory());
 
                 if (protoFiles.isEmpty()) {
@@ -150,7 +159,7 @@ abstract class AbstractProtocMojo extends AbstractMojo {
                     ImmutableSet<File> derivedProtoPathElements =
                             makeProtoPathFromJars(temporaryProtoFileDirectory, getDependencyArtifactFiles());
                     outputDirectory.mkdirs();
-
+                    nativeOutputDirectory.mkdirs();
                     // Quick fix to fix issues with two mvn installs in a row (ie no clean)
                     cleanDirectory(outputDirectory);
 
@@ -158,7 +167,9 @@ abstract class AbstractProtocMojo extends AbstractMojo {
                             .addProtoPathElement(protoSourceRoot)
                             .addProtoPathElements(derivedProtoPathElements)
                             .addProtoPathElements(asList(additionalProtoPathElements))
-                            .addProtoFiles(protoFiles)
+			    .addProtoFiles(protoFiles)
+                            .setNativeOutputDirectory(nativeOutputDirectory)
+                            .setGeneratePythonSources(generatePythonSources)
                             .build();
                     final int exitStatus = protoc.compile();
                     if (exitStatus != 0) {
@@ -220,6 +231,8 @@ abstract class AbstractProtocMojo extends AbstractMojo {
     protected abstract List<Artifact> getDependencyArtifacts();
 
     protected abstract File getOutputDirectory();
+
+    protected abstract File getNativeOutputDirectory();
 
     protected abstract void attachFiles();
 

--- a/src/main/java/com/google/protobuf/maven/ProtocCompileMojo.java
+++ b/src/main/java/com/google/protobuf/maven/ProtocCompileMojo.java
@@ -7,9 +7,9 @@ import java.io.File;
 import java.util.List;
 
 /**
- * This mojo executes the {@code protoc} compiler for generating java sources
- * from protocol buffer definitions. It also searches dependency artifacts for
- * proto files and includes them in the protopath so that they can be
+ * This mojo executes the {@code protoc} compiler for generating java and python
+ * sources from protocol buffer definitions. It also searches dependency artifacts
+ * for proto files and includes them in the protopath so that they can be
  * referenced. Finally, it adds the proto files to the project as resources so
  * that they are included in the final artifact.
  *
@@ -36,6 +36,14 @@ public final class ProtocCompileMojo extends AbstractProtocMojo {
      */
     private File outputDirectory;
 
+    /**
+     * This is the directory into which the native proto classes will be created.
+     *
+     * @parameter default-value="${project.build.directory}/proto/"
+     * @required
+     */
+    private File nativeOutputDirectory;
+
     @Override
     protected List<Artifact> getDependencyArtifacts() {
         // TODO(gak): maven-project needs generics
@@ -47,6 +55,11 @@ public final class ProtocCompileMojo extends AbstractProtocMojo {
     @Override
     protected File getOutputDirectory() {
         return outputDirectory;
+    }
+
+    @Override
+    protected File getNativeOutputDirectory() {
+	return nativeOutputDirectory;
     }
 
     @Override

--- a/src/main/java/com/google/protobuf/maven/ProtocTestCompileMojo.java
+++ b/src/main/java/com/google/protobuf/maven/ProtocTestCompileMojo.java
@@ -29,6 +29,14 @@ public final class ProtocTestCompileMojo extends AbstractProtocMojo {
      */
     private File outputDirectory;
 
+    /**
+     * This is the directory into which the native proto classes will be created.
+     *
+     * @parameter default-value="${project.build.directory}/proto/"
+     * @required
+     */
+    private File nativeOutputDirectory;
+
     @Override
     protected void attachFiles() {
         project.addTestCompileSourceRoot(outputDirectory.getAbsolutePath());
@@ -47,6 +55,11 @@ public final class ProtocTestCompileMojo extends AbstractProtocMojo {
     @Override
     protected File getOutputDirectory() {
         return outputDirectory;
+    }
+
+    @Override
+    protected File getNativeOutputDirectory() {
+        return nativeOutputDirectory;
     }
 
     @Override


### PR DESCRIPTION
I have a multi-module maven project which needs to share proto files between java and python.  This plugin is a great start for doing that, and is much cleaner than trying to manually construct those command lines using maven exec.
